### PR TITLE
rollback時にhookを先に初期化する

### DIFF
--- a/lib/DBIx/Class/Storage/TxnEndHook.pm
+++ b/lib/DBIx/Class/Storage/TxnEndHook.pm
@@ -48,8 +48,8 @@ sub txn_commit {
 
 sub txn_rollback {
     my $self = shift;
-    my @ret = $self->next::method(@_);
     $self->_hooks([]);
+    my @ret = $self->next::method(@_);
     @ret;
 }
 


### PR DESCRIPTION
txn_rollbackが例外吐いたときにhookが初期化されない問題を修正しました。
レビュー宜しくお願いします。
