### PR TITLE
add warning-prefix

### DIFF
--- a/lib/DBIx/Class/Storage/TxnEndHook.pm
+++ b/lib/DBIx/Class/Storage/TxnEndHook.pm
@@ -39,7 +39,7 @@ sub txn_commit {
         }
         catch {
             $self->_hooks([]);
-            warn $_;
+            warn "[TxnEndHook]" . $_;
         };
     }
 

--- a/lib/DBIx/Class/Storage/TxnEndHook.pm
+++ b/lib/DBIx/Class/Storage/TxnEndHook.pm
@@ -10,6 +10,8 @@ __PACKAGE__->mk_group_accessors(simple => qw/_hooks/);
 
 our $VERSION = "0.01";
 
+our $WARN_PREFIX = "";
+
 sub new {
     my $self = shift->next::method(@_);
     $self->_hooks([]);
@@ -39,7 +41,7 @@ sub txn_commit {
         }
         catch {
             $self->_hooks([]);
-            warn "[TxnEndHook]" . $_;
+            warn $WARN_PREFIX . $_;
         };
     }
 
@@ -51,6 +53,11 @@ sub txn_rollback {
     my @ret = $self->next::method(@_);
     $self->_hooks([]);
     @ret;
+}
+
+sub warn_prefix {
+    my $class = shift;
+    $WARN_PREFIX = shift;
 }
 
 1;


### PR DESCRIPTION
TxnEndHook内で例外が発生したとき、warningが出力されますが、これがEndHook内で起きた物であることを明示するためにwarningにPrefixをつけられる機能を追加したいです。

EndHook内で例外が発生したことを検知したいのですが、標準エラー出力にはEndHook由来でないwarningが流れることも多く、どれがEndHookの例外由来のwarningであるかを判別しづらい状況にあります。そこでPrefixをつけることによって、EndHook由来のwarningをフィルタリングできるようにしてログ監視しやすくしたいということが目的となります。